### PR TITLE
Consider hyphens & other specials to be non-words

### DIFF
--- a/rebel-readline/src/rebel_readline/widgets/base.clj
+++ b/rebel-readline/src/rebel_readline/widgets/base.clj
@@ -487,9 +487,13 @@
       (set-key-map! "viins" clojure-viins)
       (set-key-map! "vicmd" clojure-vicmd))))
 
+(defn set-word-characters [line-reader]
+  (doto line-reader (.setVariable LineReader/WORDCHARS "")))
+
 (defn add-default-widgets-and-bindings [line-reader]
   (binding [*line-reader* line-reader]
     (doto line-reader
+      set-word-characters
       add-all-widgets
       add-clojure-emacs-key-map
       add-clojure-vi-key-maps)


### PR DESCRIPTION
The DEFAULT_WORDCHARLIST from Jline3 is: `"*?_-.[]~=/&;!#$%^(){}<>"` so, for example, backwards-killing from the end of `map-indexed` would now be `map-` instead of an empty line. Similar for the other non-hypen characters, e.g. `org.jline.utils.InfoCmp$Capability` backs up to `org.jline.utils.InfoCmp`, `org.jline.utils.`, etc.

This blanks those out, so that forward/backward navigation, killing, etc. is done in smaller increments.

I think this addresses #66, but I'm not 100% sure, so I may be projecting my own meaning onto that.