### PR TITLE
Add no.disassemble widget

### DIFF
--- a/rebel-readline/project.clj
+++ b/rebel-readline/project.clj
@@ -14,7 +14,8 @@
                  [org.jline/jline-terminal "3.5.1"]
                  [org.jline/jline-terminal-jansi "3.5.1"]
                  [cljfmt "0.5.7"]     ;; depends on tools reader
-                 [compliment "0.3.6"]]
+                 [compliment "0.3.6"]
+                 [nodisassemble "0.1.3"]]
 
   :profiles {:dev {:source-paths ["src" "dev"]
                    :main rebel-dev.main}})

--- a/rebel-readline/src/rebel_readline/clojure/line_reader.clj
+++ b/rebel-readline/src/rebel_readline/clojure/line_reader.clj
@@ -749,13 +749,12 @@
     (highlight-clj-str disassembly)))
 
 (defn disassemble-at-point []
-  (when-let [[wrd] (word-at-cursor)]
-    (when-let [{:keys [result exception] :as eval-result} (evaluate-str wrd)]
-      (if exception
-        eval-result
-        (let [disassembly (disassemble result)]
-          (when-not (string/blank? disassembly)
-            {:disassembly (string/trim disassembly)}))))))
+  (when-let [{:keys [result exception] :as eval-result} (in-place-eval)]
+    (if exception
+      eval-result
+      (let [disassembly (disassemble result)]
+        (when-not (string/blank? disassembly)
+          {:disassembly (string/trim disassembly)})))))
 
 (def disassemble-at-point-widget
   (create-widget


### PR DESCRIPTION
In line with the eval, source and doc widgets, this PR adds a [no.disassemble](https://github.com/gtrak/no.disassemble) widget to disassemble to byte code directly in the REPL.

![image](https://user-images.githubusercontent.com/3405586/36819317-59daa306-1ce9-11e8-8082-4214ba065e90.png)

~Right now, the widget operates on the word under the cursor, but ideally it should operate on forms just like the eval widget. That could either be added later as an extension or in this PR if you think that is better.~ Fixed in https://github.com/bhauman/rebel-readline/pull/124/commits/05673eaba1f14006733ab6a4a97e3113c15eb963?w=1.

It kind of sucks to add `no.disassembly` as a dependency since most users are probably not interested in this functionality. I don't know enough about Clojure builds to suggest a solution, but maybe there is some good way to make this feature and its dependency optional?

Thanks for a great library, looking forward to use this in my daily Clojure programming and hopefully hack away at it some more!

