### PR TITLE
Properly catch number parsing errors

### DIFF
--- a/rebel-readline/src/rebel_readline/utils.clj
+++ b/rebel-readline/src/rebel_readline/utils.clj
@@ -19,8 +19,8 @@
 
 (defn terminal-background-color? []
   (or (when-let [fgbg (System/getenv "COLORFGBG")]
-        (when-let [[fg bg] (try (map #(Integer/parseInt (string/trim %))
-                                     (string/split fgbg #";"))
+        (when-let [[fg bg] (try (mapv #(Integer/parseInt (string/trim %))
+                                      (string/split fgbg #";"))
                                 (catch Throwable t nil))]
           (when (and fg bg)
             (if (< -1 fg bg 16)


### PR DESCRIPTION
Solves #137 .
Lazy evaluation = nothing catched. Working fine now!