### PR TITLE
fix #139: swap not returning true on key-map change

### DIFF
--- a/rebel-readline/src/rebel_readline/jline_api.clj
+++ b/rebel-readline/src/rebel_readline/jline_api.clj
@@ -268,7 +268,8 @@ If you are using `lein` you may need to use `lein trampoline`."
       (deref [] (.getVariable this service-variable-name))
       ;; TODO implement all swaps??
       (swap  [f & args] (swap* this f args))
-      (reset [a] (.setVariable this service-variable-name a)))))
+      (reset [a] (do (.setVariable this service-variable-name a)
+                     true)))))
 
 ;; taken from Clojure 1.10 core.print
 (defn- ^java.io.PrintWriter PrintWriter-on*


### PR DESCRIPTION
I've been looking into the issue #139 and it happened that the problem comes ultimately from your implementation of swap which failed to return true on successful change. Once spotted, the fix is a tiny one.

I tested but manually... :

```clojure
rebel-dev.main=> (:key-map @api/*line-reader*)   
:emacs  
rebel-dev.main=> :repl/set-key-map :viins  
Changed key map to :viins  
rebel-dev.main=> (:key-map @api/*line-reader*)  
:viins  
```