### PR TITLE
Defer loading of cljfmt and compliment to improve startup time

### DIFF
--- a/rebel-readline/project.clj
+++ b/rebel-readline/project.clj
@@ -13,6 +13,7 @@
                  [org.jline/jline-reader "3.5.1"]
                  [org.jline/jline-terminal "3.5.1"]
                  [org.jline/jline-terminal-jansi "3.5.1"]
+                 [com.clojure-goes-fast/lazy-require "0.1.1"]
                  [cljfmt "0.5.7"]     ;; depends on tools reader
                  [compliment "0.3.6"]]
 

--- a/rebel-readline/src/rebel_readline/clojure/line_reader.clj
+++ b/rebel-readline/src/rebel_readline/clojure/line_reader.clj
@@ -7,7 +7,7 @@
    [rebel-readline.clojure.sexp :as sexp]
    [rebel-readline.tools :as tools :refer [color service-dispatch]]
    [rebel-readline.utils :as utils :refer [log]]
-   [cljfmt.core :refer [reformat-string]]
+   [lazy-require.core :as lreq]
    [clojure.string :as string]
    [clojure.java.io :as io]
    [clojure.main])
@@ -440,14 +440,15 @@
   (if (zero? cursor)
     0
     (if-let [prx (indent-proxy-str s cursor)]
-      (try (->>
-            (reformat-string prx {:remove-trailing-whitespace? false
-                                  :insert-missing-whitespace? false
-                                  :remove-surrounding-whitespace? false
-                                  :remove-consecutive-blank-lines? false})
-            string/split-lines
-            last
-            sexp/count-leading-white-space)
+      (try (lreq/with-lazy-require [[cljfmt.core :as cljfmt]]
+             (->>
+              (cljfmt/reformat-string prx {:remove-trailing-whitespace? false
+                                           :insert-missing-whitespace? false
+                                           :remove-surrounding-whitespace? false
+                                           :remove-consecutive-blank-lines? false})
+              string/split-lines
+              last
+              sexp/count-leading-white-space))
            (catch clojure.lang.ExceptionInfo e
              (if (-> e ex-data :type (= :reader-exception))
                (+ 2 (sexp/count-leading-white-space prx))

--- a/rebel-readline/src/rebel_readline/clojure/main.clj
+++ b/rebel-readline/src/rebel_readline/clojure/main.clj
@@ -5,7 +5,8 @@
    [rebel-readline.jline-api :as api]
    [rebel-readline.tools :as tools]
    [rebel-readline.clojure.service.local :as clj-service]
-   [clojure.main]))
+   [clojure.main]
+   [lazy-require.core :as lreq]))
 
 (defn syntax-highlight-prn
   "Print a syntax highlighted clojure value.
@@ -106,4 +107,5 @@
     :eval (partial contextual-eval (local-context))))
 
 (defn -main [& args]
+  (lreq/load-in-background) ;; Load deferred namespaces in a background thread.
   (core/ensure-terminal (repl)))


### PR DESCRIPTION
_For context, see #154._

As promised, I've made cljfmt loading lazy. While at it, I also deferred Compliment loading which was a much smaller issue but still brought some weight. The results on my local setup are:

- master: 6.3 seconds
- lazy-loading: 3.2 seconds

Since this is not the first time I implement lazy-loading functionality in a project, I've decided to extract it into a library. I know you don't want to add many dependencies to rebel-readline (which slows down the start, that's the whole point), but this one is just a few functions and surely will never have any dependencies on its own. Here it is: https://github.com/clojure-goes-fast/lazy-require

So, cljfmt and Compliment are required lazily now. However, they are actually being loaded in the background, so if the user trigger indentation/completion in the first 2-3 seconds, they won't experience the deferred loading lag. (If that becomes an issue with completion, we can always put Compliment back on the eager list. It doesn't add more than 300ms).

Please, tell me what you think. I'll be happy to iterate.