### PR TITLE
Allow for passing options to .readLine

### DIFF
--- a/rebel-readline/src/rebel_readline/core.clj
+++ b/rebel-readline/src/rebel_readline/core.clj
@@ -83,7 +83,21 @@
   "[Rebel readline] Type :repl/help for online help info")
 
 (defn read-line-opts
-  "Like read-line, but allows overriding of the LineReader prompt, buffer, and mask parameters."
+  "Like read-line, but allows overriding of the LineReader prompt, buffer, and mask parameters.
+   
+   :prompt 
+     Allows overriding with a cusom prompt
+   :buffer
+     The default value presented to the user to edit, may be null.
+   :mask 
+     Should be set to a single character used by jline to bit-mask.  
+     Characters will not be echoed if they mask to 0
+     Might do crazy stuff with rebel-readline, use with caution.
+     defaults to nil (no mask)
+   :command-executed
+     sentinal value to be returned when a repl command is executed, otherwise a 
+     blank string will be returned when a repl command is executed.
+  "
   [ & {prompt :prompt
        mask :mask
        buffer :buffer 

--- a/rebel-readline/src/rebel_readline/core.clj
+++ b/rebel-readline/src/rebel_readline/core.clj
@@ -102,7 +102,7 @@
        mask :mask
        buffer :buffer 
        command-executed :command-executed
-       :or {prompt (tools/prompt) buffer nil mask nil command-executed ""}}]
+       :or {prompt nil buffer nil mask nil command-executed ""}}]
   
   (let [redirect-output? (:redirect-output @api/*line-reader*)
         save-out (volatile! *out*)
@@ -119,7 +119,7 @@
         ;; but we are blocking concurrent redisplays while the
         ;; readline prompt is initially drawn
         (api/block-redisplay-millis 100)
-        (let [res' (.readLine api/*line-reader* prompt mask buffer)]
+        (let [res' (.readLine api/*line-reader* (or prompt (tools/prompt)) mask buffer)]
           (if-not (commands/handle-command res')
             res'
             command-executed)))


### PR DESCRIPTION
LOVE this library, was about to go write the same thing, then found this.

I have a use case with an interactive shell hosted by my program (not a repl) where I want to allow pro-mode users to directly edit certain chunks of state (generally loaded in from external edn config files).  Calling readLine with the current value already in the buffer seemed like the perfect solution, but there was no way to pass down a buffer value without just redefing `rebel-readline.core/read-line`

Obvious solution seemed to be moving the meat of `rebel-readline.core/read-line` up into a new function that allowed the options to be passed down, and changing read-line to call that one.

I'm happy to restructure this in a different way if there's something that seems more idiomatic to you.

Side-note, I also added an option to pass down readLine's "mask" parameter which seems unlikely to be useful to anyone, but I figured I should toss it in for completeness