### PR TITLE
Lightweight Ctrl-C interruption handling

### DIFF
--- a/rebel-readline/src/rebel_readline/clojure/main.clj
+++ b/rebel-readline/src/rebel_readline/clojure/main.clj
@@ -5,7 +5,13 @@
    [rebel-readline.jline-api :as api]
    [rebel-readline.tools :as tools]
    [rebel-readline.clojure.service.local :as clj-service]
+   [clojure.repl :as repl]
    [clojure.main]))
+
+(defn- handle-sigint-form
+  []
+  `(let [thread# (Thread/currentThread)]
+     (repl/set-break-handler! (fn [_signal#] (.stop thread#)))))
 
 (defn syntax-highlight-prn
   "Print a syntax highlighted clojure value.
@@ -82,6 +88,8 @@
         (apply
          clj-repl
          (-> {:print syntax-highlight-prn
+              :eval (fn [form]
+                      (eval `(do ~(handle-sigint-form) ~form)))
               :read (create-repl-read)}
              (merge opts {:prompt (fn [])})
              seq


### PR DESCRIPTION
Right now if pressed Ctrl-C it exits REPL completely, and this makes a huge difference with what we used to see with `lein repl` and others.

This fixes it

```
user=> (Thread/sleep 10000)
Execution error (ThreadDeath) at java.lang.Thread/stop (Thread.java:942).
null
```