### PR TITLE
Update readme to fix deprecated usage of -A option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Alternatively you can specify an alias in your `$HOME/.clojure/deps.edn`
 And then run with a simpler:
 
 ```shell
-$ clojure -A:rebel
+$ clojure -M:rebel
 ```
 
 #### Leiningen

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Alternatively you can specify an alias in your `$HOME/.clojure/deps.edn`
 And then run with a simpler:
 
 ```shell
-$ clojure -M:rebel
+clojure -M:rebel
 ```
 
 #### Leiningen


### PR DESCRIPTION
Old version:

```
 clojure -A:rebel       
WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
```

fixed version:
```
 clojure -M:rebel       
[Rebel readline] Type :repl/help for online help info
user=> 
```