### PR TITLE
fix clojars url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rebel-readline
 
-[![Clojars Project](https://img.shields.io/clojars/v/com.bhauman/rebel-readline.svg)](https://clojars.org)
+[![Clojars Project](https://img.shields.io/clojars/v/com.bhauman/rebel-readline.svg)](https://clojars.org/com.bhauman/rebel-readline)
 [![Clojars Project](https://img.shields.io/clojars/v/com.bhauman/rebel-readline-cljs.svg)](https://clojars.org/com.bhauman/rebel-readline-cljs)
 
 A terminal readline library for Clojure Dialects


### PR DESCRIPTION
Changed the clojars url for Rebel Readline in the readme so it points to rebel's clojar page, rather than clojar's homepage.