### PR TITLE
Neutral theme

### DIFF
--- a/rebel-readline/src/rebel_readline/tools.clj
+++ b/rebel-readline/src/rebel_readline/tools.clj
@@ -201,3 +201,37 @@
          :widget/apropos-namespace  (fg-color 243)))
 
 (register-color-theme! :light-screen-theme light-screen-theme)
+
+(def neutral-screen-theme
+  {:font-lock/string         (.bold (fg-color 2))
+   :font-lock/comment        (.bold (fg-color 8))
+   :font-lock/doc            (.bold (fg-color 5))
+   :font-lock/core-form      (.bold (fg-color 2))
+   :font-lock/function-name  (.bold (fg-color 6))
+   :font-lock/variable-name  (.bold (fg-color 3))
+   :font-lock/constant       (.bold (fg-color 4))
+   :font-lock/type           (.bold (fg-color 1))
+   :font-lock/foreign        (.bold (fg-color 1))
+   :font-lock/builtin        (.bold (fg-color 6))
+
+   :widget/half-contrast     (fg-color 7)
+   :widget/half-contrast-inverse (.inverse (fg-color 7))
+
+   ;; system widget colors
+   :widget/eldoc-namespace   (.faint (fg-color 2))
+   :widget/eldoc-varname     (.faint (fg-color 3))
+   :widget/eldoc-separator   (fg-color 4)
+   :widget/arglists          (fg-color 5)
+
+   :widget/doc               (fg-color 1)
+   :widget/anchor            (fg-color 5)
+   :widget/light-anchor      (.faint (fg-color 5))
+
+   :widget/apropos-word      AttributedStyle/DEFAULT
+   :widget/apropos-highlight (fg-color 7)
+   :widget/apropos-namespace (.faint (fg-color 7))
+
+   :widget/warning           AttributedStyle/DEFAULT
+   :widget/error             (fg-color 1)})
+
+(register-color-theme! :neutral-screen-theme neutral-screen-theme)


### PR DESCRIPTION
This MR adds a neutral theme, that is limited to the basic 16 ANSI colors. This allows the terminal emulator colorscheme to flow through to the REPL as demonstrated in the pictures below:

This is very much like other neutral themes like: https://github.com/jeffkreeftmeijer/vim-dim

![s1](https://user-images.githubusercontent.com/217393/227415283-214fb38a-8ba1-4b04-ab1f-da2c16897362.png)
![s2](https://user-images.githubusercontent.com/217393/227415305-9dd2216f-8ac0-4de3-aced-7952cb63e4ae.png)
![s3](https://user-images.githubusercontent.com/217393/227415329-83de556a-a008-4377-8af3-e2dbb2827c4b.png)
![s4](https://user-images.githubusercontent.com/217393/227415338-d2fcdff0-77c6-437b-8098-b5538ce76711.png)
![s5](https://user-images.githubusercontent.com/217393/227415344-e4a6ca67-9677-41dd-bef1-598f2149c6f5.png)
![s6](https://user-images.githubusercontent.com/217393/227415352-92f81adf-a59e-4cf0-b78e-ee46759001cb.png)
![s7](https://user-images.githubusercontent.com/217393/227415356-c5e3f1a5-4719-464a-bd0b-6c2e74494d47.png)
![s8](https://user-images.githubusercontent.com/217393/227415366-706d2759-7851-48a0-813e-e803cc2dfa0f.png)
![s9](https://user-images.githubusercontent.com/217393/227415372-d9f5e282-91ff-475b-ab4d-5b058e740ba8.png)
