### PR TITLE
readme: fix asciicast link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Welcome to **Rebel Readline** – the snazzy terminal REPL for Clojure!
 
-![asciicast](https://asciinema.org/a/160597.png)
+[![asciicast](https://asciinema.org/a/160597.png)](https://asciinema.org/a/160597)
 
 ## Features
 


### PR DESCRIPTION
The image in the readme has a big play button on it, but if you click it you end up at a static image, not the movie.
This PR adds a link around the image linking to the actual asciicast.
