### PR TITLE
Update instructions to use 0.1.5 and use --enable-native-access=ALL-UNNAMED to avoid warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The line reader requires direct terminal access. Therefore, do not launch Rebel 
 To quickly try Rebel Readline, [install the Clojure CLI tools](https://clojure.org/guides/getting_started) and execute:
 
 ```shell
-clojure -Sdeps "{:deps {com.bhauman/rebel-readline {:mvn/version \"0.1.5\"}}}" -M -m rebel-readline.main
+clojure -J--enable-native-access=ALL-UNNAMED -Sdeps "{:deps {com.bhauman/rebel-readline {:mvn/version \"0.1.5\"}}}" -M -m rebel-readline.main
 ```
 
 ## Usage
@@ -81,6 +81,7 @@ Add Rebel Readline as a tool within your `~/.clojure/deps.edn`:
  :aliases {:rebel {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.5"}}
                    :exec-fn rebel-readline.tool/repl
                    :exec-args {}
+                   :jvm-opts ["--enable-native-access=ALL-UNNAMED"]
                    :main-opts ["-m" "rebel-readline.main"]}}
  ...
 }

--- a/rebel-readline/README.md
+++ b/rebel-readline/README.md
@@ -37,7 +37,7 @@ If you want to try this really quickly
 and then invoke this:
 
 ```shell
-clojure -Sdeps "{:deps {com.bhauman/rebel-readline {:mvn/version \"0.1.4\"}}}" -m rebel-readline.main
+clojure -J--enable-native-access=ALL-UNNAMED -Sdeps "{:deps {com.bhauman/rebel-readline {:mvn/version \"0.1.5\"}}}" -m rebel-readline.main
 ```
 
 That should start a Clojure REPL that takes its input from the Rebel readline editor.
@@ -50,7 +50,10 @@ Alternatively you can specify an alias in your `$HOME/.clojure/deps.edn`
 ```clojure
 {
  ...
- :aliases {:rebel {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.4"}}
+ :aliases {:rebel {:extra-deps {com.bhauman/rebel-readline {:mvn/version "0.1.5"}}
+                   :exec-fn rebel-readline.tool/repl
+                   :exec-args {}
+                   :jvm-opts ["--enable-native-access=ALL-UNNAMED"]
                    :main-opts  ["-m" "rebel-readline.main"]}}
 }
 ```
@@ -63,7 +66,7 @@ $ clojure -A:rebel
 
 #### Leiningen
 
-Add `[com.bhauman/rebel-readline "0.1.4"]` to the dependencies in your
+Add `[com.bhauman/rebel-readline "0.1.5"]` to the dependencies in your
 `project.clj` then start a REPL like this:
 
 ```shell
@@ -75,7 +78,7 @@ Alternatively, you can add rebel-readline globally to `$HOME/.lein/profiles.clj`
 ```clojure
 {
  ...
- :user {:dependencies [[com.bhauman/rebel-readline "0.1.4"]]}
+ :user {:dependencies [[com.bhauman/rebel-readline "0.1.5"]]}
 }
 ```
 

--- a/rebel-readline/deps.edn
+++ b/rebel-readline/deps.edn
@@ -5,9 +5,12 @@
         dev.weavejester/cljfmt {:mvn/version "0.13.0"}
         compliment/compliment {:mvn/version "0.6.0"}}
  :tools/usage {:ns-default rebel-readline.tool}
- :aliases {:repl-tool {:exec-fn rebel-readline.tool/repl}
-           :rebel {:main-opts  ["-m" "rebel-readline.main"]}
+ :aliases {:repl-tool {:jvm-opts ["--enable-native-access=ALL-UNNAMED"]
+                       :exec-fn rebel-readline.tool/repl}
+           :rebel {:jvm-opts ["--enable-native-access=ALL-UNNAMED"]
+                   :main-opts  ["-m" "rebel-readline.main"]}
            :dev {:extra-paths ["dev"]
+                 :jvm-opts ["--enable-native-access=ALL-UNNAMED"]
                  :main-opts ["-m" "rebel-dev.main"]}
            ;; build
            :neil {:project {:name com.bhauman/rebel-readline


### PR DESCRIPTION
This commit updates all references of version 0.1.4 to 0.1.5, and adds to the JVM options the following:

```
  --enable-native-access=ALL-UNNAMED
```

Otherwise, when running we would get the following warning:

```
  WARNING: A restricted method in java.lang.System has been called
  WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:[...]/jline-3.30.6.jar)
  WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
  WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

This is related to this issue with jline 3 "[WARNING: A restricted method in java.lang.System has been called
(JDK24) #1067](https://github.com/jline/jline3/issues/1067)".