### PR TITLE
This partially addresses issue 157, by adding support for a `-i` command line argument with tools.deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Options:
       --no-redirect-output                         Disable output redirection
   -b, --key-bindings BINDINGS                      Specify custom key bindings
   -c, --config CONFIG                              Path to a config file
+  -i, --init INIT                                  Path to an initialization script (Clojure source)
 ```
 
 ## Installing with Leiningen

--- a/rebel-readline/deps.edn
+++ b/rebel-readline/deps.edn
@@ -1,9 +1,9 @@
-{:deps {org.clojure/clojure {:mvn/version "1.10.0"}
-        org.jline/jline-reader {:mvn/version "3.30.0"}
-        org.jline/jline-terminal {:mvn/version "3.30.0"}
-        org.jline/jline-terminal-jni {:mvn/version "3.30.0"}
-        dev.weavejester/cljfmt {:mvn/version "0.13.0"}
-        compliment/compliment {:mvn/version "0.6.0"}}
+{:deps {org.clojure/clojure {:mvn/version "1.12.4"}
+        org.jline/jline-reader {:mvn/version "4.0.12"}
+        org.jline/jline-terminal {:mvn/version "4.0.12"}
+        org.jline/jline-terminal-jni {:mvn/version "4.0.12"}
+        dev.weavejester/cljfmt {:mvn/version "0.16.3"}
+        compliment/compliment {:mvn/version "0.7.1"}}
  :tools/usage {:ns-default rebel-readline.tool}
  :aliases {:repl-tool {:exec-fn rebel-readline.tool/repl}
            :rebel {:main-opts  ["-m" "rebel-readline.main"]}
@@ -11,8 +11,8 @@
                  :main-opts ["-m" "rebel-dev.main"]}
            ;; build
            :neil {:project {:name com.bhauman/rebel-readline
-                            :version "0.1.7"}}
-           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.6"
-                                                         :git/sha "52cf7d6"}
-                          slipset/deps-deploy {:mvn/version "0.2.2"}}
+                            :version "0.1.8-SNAPSHOT"}}
+           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.13"
+                                                         :git/sha "ae52edf"}
+                          slipset/deps-deploy {:mvn/version "0.2.3"}}
                    :ns-default build}}}

--- a/rebel-readline/src/rebel_readline/clojure/init_script/post_1.12.clj
+++ b/rebel-readline/src/rebel_readline/clojure/init_script/post_1.12.clj
@@ -1,0 +1,8 @@
+(in-ns 'rebel-readline.clojure.main)
+
+(defn- load-init-script
+  [init-script]
+  (let [cl (.getContextClassLoader (Thread/currentThread))]
+    (.setContextClassLoader (Thread/currentThread) (clojure.lang.DynamicClassLoader. cl))  ; Required for clojure.repl.deps/add-libs (1.12+)
+    (binding [*repl* true]                                                                 ; Required for clojure.repl.deps/add-libs (1.12+)
+      (load-file init-script))))

--- a/rebel-readline/src/rebel_readline/clojure/init_script/pre_1.12.clj
+++ b/rebel-readline/src/rebel_readline/clojure/init_script/pre_1.12.clj
@@ -1,0 +1,5 @@
+(in-ns 'rebel-readline.clojure.main)
+
+(defn- load-init-script
+  [init-script]
+  (load-file init-script))

--- a/rebel-readline/src/rebel_readline/clojure/main.clj
+++ b/rebel-readline/src/rebel_readline/clojure/main.clj
@@ -85,6 +85,12 @@
    core/has-remaining?
    clojure.main/repl-read))
 
+;; Define Clojure-version-specific load-init-script fns, in order to support
+;; clojure.repl.deps/add-libs on Clojure 1.12+
+(if (ns-resolve 'clojure.core '*repl*)
+  (load-file "init_script/post_1.12.clj")
+  (load-file "init_script/pre_1.12.clj"))
+
 (let [clj-repl clojure.main/repl]
   (defn repl* [{:keys [:rebel-readline/config] :as opts}]
     (let [opts (dissoc opts :rebel-readline/config)
@@ -107,6 +113,8 @@
           (binding [*out* (api/safe-terminal-writer api/*line-reader*)]
             (when-let [prompt-fn (:prompt opts)]
               (swap! api/*line-reader* assoc :prompt prompt-fn))
+            (when-let [init-script (:init-script final-config)]
+              (load-init-script init-script))
             (println (core/help-message))
             (apply
              clj-repl
@@ -116,9 +124,7 @@
                   :read (create-repl-read)}
                  (merge opts {:prompt (fn [])})
                  seq
-                 flatten))))
-      (when (:init opts)
-        (load-file (:init opts))))))
+                 flatten)))))))
 
 (defn repl [& opts]
   (repl* (apply hash-map opts)))

--- a/rebel-readline/src/rebel_readline/clojure/main.clj
+++ b/rebel-readline/src/rebel_readline/clojure/main.clj
@@ -116,7 +116,9 @@
                   :read (create-repl-read)}
                  (merge opts {:prompt (fn [])})
                  seq
-                 flatten)))))))
+                 flatten))))
+      (when (:init opts)
+        (load-file (:init opts))))))
 
 (defn repl [& opts]
   (repl* (apply hash-map opts)))

--- a/rebel-readline/src/rebel_readline/clojure/main.clj
+++ b/rebel-readline/src/rebel_readline/clojure/main.clj
@@ -88,8 +88,8 @@
 ;; Define Clojure-version-specific load-init-script fns, in order to support
 ;; clojure.repl.deps/add-libs on Clojure 1.12+
 (if (ns-resolve 'clojure.core '*repl*)
-  (load-file "init_script/post_1.12.clj")
-  (load-file "init_script/pre_1.12.clj"))
+  (load "init_script/post_1.12")
+  (load "init_script/pre_1.12"))
 
 (let [clj-repl clojure.main/repl]
   (defn repl* [{:keys [:rebel-readline/config] :as opts}]

--- a/rebel-readline/src/rebel_readline/main.clj
+++ b/rebel-readline/src/rebel_readline/main.clj
@@ -49,6 +49,10 @@
     :validate [map? "Must be a map"]]
    ["-c" "--config CONFIG" "Path to a config file"
     :parse-fn (comp str tools/absolutize-file)
+    :validate [#(.exists (io/file %)) "Must be a valid path to a readable file"]]
+   ["-i" "--init SCRIPT" "Path to an init script (a Clojure source file)"
+    :id :init-script
+    :parse-fn (comp str tools/absolutize-file)
     :validate [#(.exists (io/file %)) "Must be a valid path to a readable file"]]])
 
 (defn usage [options-summary]

--- a/rebel-readline/src/rebel_readline/tools.clj
+++ b/rebel-readline/src/rebel_readline/tools.clj
@@ -122,6 +122,7 @@
 #_(absolutize-file "~/workspace/rebel-readline/rebel-readline/./src/../README.md")
 
 (s/def ::config (s/and string? file-exists?))
+(s/def ::init   (s/and string? file-exists?))
 (s/def ::arg-map (s/keys :opt-un [::key-map
                                   ::color-theme
                                   ::highlight
@@ -129,7 +130,8 @@
                                   ::eldoc
                                   ::indent
                                   ::redirect-output
-                                  ::key-bindings]))
+                                  ::key-bindings
+                                  ::init]))
 
 (defn explain-config-header [config]
   (println "Arguments didn't pass spec")


### PR DESCRIPTION
> When contributing:
> * File an issue for non-trivial changes before creating a PR.

This addresses part of issue #157 (i.e. it adds support for init scripts with tools.deps only).

> * Consolidate PR changes into one commit.

I couldn't figure out how to do this, but I believe it can be done with "squash commits" when the PR is merged?

> * Make changes small and easy to understand; this allows for better review.

I did my best to achieve this.

> * Break larger solutions into manageable PRs.

I did my best to achieve this.

> * Communicate if a PR represents more exploratory efforts.

This isn't really "exploratory" per se - I've had a need for this for a long time (as [my comment on issue #157 from 2021 suggests](https://github.com/bhauman/rebel-readline/issues/157#issuecomment-991943601)).  I don't consider it exhaustively tested however, as the REPL space in general (and rebel-readline specifically) are not areas I have in depth knowledge of as anything but a user.

Detailed test notes:
* This was tested with both Clojure 1.10.1 and 1.12.4 (hence the upgraded dependencies in `project.clj`), especially since this PR includes Clojure-version-specific logic.
* I successfully tested a simple init script on both Clojure versions.
* On Clojure 1.12.4, I also successfully tested an init script that dynamically loaded additional libraries into the REPL's classpath (using `clojure.repl.deps/add-libs`).  On Clojure 1.10.1 it also failed correctly (i.e. Clojure was unable to find that namespace).
* While I did use this fork of rebel-readline while working on an unrelated project (which has a fairly complex init script) for around an hour, and didn't encounter any issues, I wouldn't consider this PR to have been exhaustively regression tested.  My REPL needs are fairly mundane, so it's quite plausible that despite my best efforts I broke some aspect of rebel-readline's behaviour.

Here's how to test this PR without having to check anything out manually:
```shell
$ clojure -Sdeps "{:deps {com.github.pmonks/rebel-readline {:git/sha \"14818b4135da4aa8d6c6e377b451749a518043ca\" :deps/root \"rebel-readline\"}}}" -M -m rebel-readline.main -i path/to/init_script.clj
```
(`path/to/init_script.clj` should be a path to a real file that exists, is readable, and contains valid Clojure code - that code should probably also start with `(in-ns 'user)`, especially if it defines any vars)

