### PR TITLE
Babashka compatibility for rebel-readline subproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ rebel-readline/.rebel_readline_history
 rebel-readline-cljs/.rebel_readline_history
 
 *.log
+.cljs_node_repl

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,1 @@
+{:deps {com.bhauman/rebel-readline {:local/root "rebel-readline"}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,1 +1,6 @@
-{:deps {com.bhauman/rebel-readline {:local/root "rebel-readline"}}}
+{:deps {com.bhauman/rebel-readline {:local/root "rebel-readline"
+                                    :deps/manifest :deps
+                                    :exclusions [#_#_#_#_org.jline/jline-reader
+                                                 org.jline/jline-terminal
+                                                 org.jline/jline-terminal-jni
+                                                 org.jline/jline-terminal-ffm]}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,6 +1,0 @@
-{:deps {com.bhauman/rebel-readline {:local/root "rebel-readline"
-                                    :deps/manifest :deps
-                                    :exclusions [#_#_#_#_org.jline/jline-reader
-                                                 org.jline/jline-terminal
-                                                 org.jline/jline-terminal-jni
-                                                 org.jline/jline-terminal-ffm]}}}

--- a/rebel-readline-cljs/deps.edn
+++ b/rebel-readline-cljs/deps.edn
@@ -1,7 +1,8 @@
 {:deps {com.bhauman/rebel-readline {:mvn/version "0.1.5"}
         org.clojure/clojurescript {:mvn/version "1.10.758"}
         cljs-tooling/cljs-tooling {:mvn/version "0.3.1"}}
- :aliases {:neil {:project {:name com.bhauman/rebel-readline-cljs
+ :aliases {:dev {:override-deps {com.bhauman/rebel-readline {:local/root "../rebel-readline"}}}
+           :neil {:project {:name com.bhauman/rebel-readline-cljs
                             :version "0.1.5"}}
            :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.6"
                                                          :git/sha "52cf7d6"}

--- a/rebel-readline-cljs/src/rebel_readline/cljs/main.clj
+++ b/rebel-readline-cljs/src/rebel_readline/cljs/main.clj
@@ -1,10 +1,10 @@
 (ns rebel-readline.cljs.main
   (:require
-   [cljs.repl.nashorn :as nash]
+   [cljs.repl.node :as node]
    [rebel-readline.cljs.repl :as cljs-repl]
    [rebel-readline.core :as core]))
 
-;; TODO need ot bring this in line with cljs.main
+;; TODO need to bring this in line with cljs.main
 (defn -main [& args]
-  (let [repl-env (nash/repl-env)]
+  (let [repl-env (node/repl-env)]
     (cljs-repl/repl repl-env)))

--- a/rebel-readline-cljs/src/rebel_readline/cljs/repl.clj
+++ b/rebel-readline-cljs/src/rebel_readline/cljs/repl.clj
@@ -49,13 +49,13 @@
   This printer respects the current color settings set in the
   service.
 
-  The `rebel-readline.jline-api/*line-reader*` and
+  The `rebel-readline.jline-api/*state*` and
   `rebel-readline.jline-api/*service*` dynamic vars have to be set for
   this to work.
 
   See `rebel-readline-cljs.main` for an example of how this function is normally used"
   [x]
-  (binding [*out* (.. api/*line-reader* getTerminal writer)]
+  (binding [*out* (.. (api/line-reader) getTerminal writer)]
     (try
       (println (api/->ansi (clj-line-reader/highlight-clj-str (or x ""))))
       (catch java.lang.StackOverflowError e
@@ -67,13 +67,13 @@
     (rebel/with-line-reader
       (clj-line-reader/create
        (cljs-service/create (assoc
-                             (when api/*line-reader*
-                               @api/*line-reader*)
+                             (when api/*state*
+                               @api/*state*)
                              :repl-env repl-env)))
       (when-let [prompt-fn (:prompt opts)]
-        (swap! api/*line-reader* assoc :prompt prompt-fn))
+        (swap! api/*state* assoc :prompt prompt-fn))
       (println (rebel/help-message))
-      (binding [*out* (api/safe-terminal-writer api/*line-reader*)]
+      (binding [*out* (api/safe-terminal-writer (api/line-reader))]
         (cljs-repl*
          repl-env
          (merge

--- a/rebel-readline-nrepl/dev/rebel_nrepl/main.clj
+++ b/rebel-readline-nrepl/dev/rebel_nrepl/main.clj
@@ -22,7 +22,7 @@
           (do
             (api/toggle-input api/*terminal* false)
             (clj-service/eval-code
-             @api/*line-reader*
+             @api/*state*
              input
              (bound-fn*
               (->> identity
@@ -45,7 +45,7 @@
                           :request-exit request-exit})]
     (try
       (clj-service/tool-eval-code
-       @api/*line-reader*
+       @api/*state*
        (pr-str `(do
                   (require 'clojure.main)
                   (require 'clojure.repl))))
@@ -66,16 +66,16 @@
     (core/with-line-reader
       (clj-line-reader/create
        (clj-service/create
-        (when api/*line-reader* @api/*line-reader*)))
-      (binding [*out* (api/safe-terminal-writer api/*line-reader*)]
-        (clj-service/start-polling @api/*line-reader*)
+        (when api/*state* @api/*state*)))
+      (binding [*out* (api/safe-terminal-writer (api/line-reader))]
+        (clj-service/start-polling @api/*state*)
         (.handle ^Terminal api/*terminal*
                  Terminal$Signal/INT
-                 (let [line-reader api/*line-reader*]
+                 (let [state api/*state*]
                    (proxy [Terminal$SignalHandler] []
                      (handle [sig]
                        (tap> "HANDLED")
-                       (clj-service/interrupt @line-reader)
+                       (clj-service/interrupt @state)
                        (tap> "AFTER INT")))))
         (println (core/help-message))
         (repl-loop)))))

--- a/rebel-readline-nrepl/src/rebel_readline/nrepl/main.clj
+++ b/rebel-readline-nrepl/src/rebel_readline/nrepl/main.clj
@@ -19,7 +19,7 @@
 
 (defn repl-caught [e]
   (println "Internal REPL Error: this shouldn't happen. :repl/*e for stacktrace")
-  (some-> @api/*line-reader* :repl/error (reset! e))
+  (some-> @api/*state* :repl/error (reset! e))
   (clojure.main/repl-caught e))
 
 (defn read-eval-print-fn [{:keys [read printer request-prompt request-exit]}]
@@ -28,16 +28,16 @@
       (let [input (read request-prompt request-exit)]
         (cond
           (#{request-prompt request-exit} input) input
-          (not (clj-service/polling? @api/*line-reader*)) request-exit
+          (not (clj-service/polling? @api/*state*)) request-exit
           :else
           (do
             (api/toggle-input api/*terminal* false)
             (clj-service/eval-code
-             @api/*line-reader*
+             @api/*state*
              input
              (bound-fn*
               (cond->> identity
-                (not (:background-print @api/*line-reader*))
+                (not (:background-print @api/*state*))
                 (clj-service/out-err
                  #(do (print %) (flush))
                  #(do (print %) (flush)))
@@ -47,7 +47,7 @@
                         (api/toggle-input api/*terminal* true)
                         (try
                           ;; we could use a more sophisticated input reader here
-                          (clj-service/send-input @api/*line-reader* (clojure.core/read-line))
+                          (clj-service/send-input @api/*state* (clojure.core/read-line))
                           (catch Throwable e
                             (repl-caught e))
                           (finally
@@ -68,14 +68,14 @@
                           :request-exit request-exit})]
     (try
       (clj-service/tool-eval-code
-       @api/*line-reader*
+       @api/*state*
        (pr-str `(do
                   (require 'clojure.main)
                   (require 'clojure.repl))))
       (catch Throwable e
         (repl-caught e)))
     (loop []
-      (when (and (clj-service/polling? @api/*line-reader*)
+      (when (and (clj-service/polling? @api/*state*)
                  (try
                    (not (identical? (read-eval-print) request-exit))
 	           (catch Throwable e
@@ -87,17 +87,17 @@
   (core/with-line-reader
       (clj-line-reader/create
        (clj-service/create
-        (merge (when api/*line-reader* @api/*line-reader*)
+        (merge (when api/*state* @api/*state*)
                options)))
-    (binding [*out* (api/safe-terminal-writer api/*line-reader*)]
-      (clj-service/register-background-printing api/*line-reader*)
-      (clj-service/start-polling @api/*line-reader*)
+    (binding [*out* (api/safe-terminal-writer (api/line-reader))]
+      (clj-service/register-background-printing api/*state*)
+      (clj-service/start-polling @api/*state*)
       (.handle ^Terminal api/*terminal*
                Terminal$Signal/INT
-               (let [line-reader api/*line-reader*]
+               (let [state api/*state*]
                  (proxy [Terminal$SignalHandler] []
                    (handle [sig]
-                     (clj-service/interrupt @line-reader)))))
+                     (clj-service/interrupt @state)))))
       (println (core/help-message))
       (repl-loop))))
 

--- a/rebel-readline-nrepl/src/rebel_readline/nrepl/service/commands.clj
+++ b/rebel-readline-nrepl/src/rebel_readline/nrepl/service/commands.clj
@@ -6,7 +6,7 @@
   "Toggle wether to continue the printing the output from backgrounded threads")
 
 (defmethod command :repl/toggle-background-print [_]
-  (swap! api/*line-reader* update :background-print #(not %))
-  (if (:background-print @api/*line-reader*)
+  (swap! api/*state* update :background-print #(not %))
+  (if (:background-print @api/*state*)
     (println "Background printing on!")
     (println "Background printing off!")))

--- a/rebel-readline-nrepl/src/rebel_readline/nrepl/service/nrepl.clj
+++ b/rebel-readline-nrepl/src/rebel_readline/nrepl/service/nrepl.clj
@@ -253,8 +253,8 @@
       (.setDaemon true)
       (.start))))
 
-(defn register-background-printing [line-reader]
-  (let [{:keys [::state background-print] :as service} @line-reader]
+(defn register-background-printing [state]
+  (let [{:keys [::state background-print] :as service} @state]
     (when background-print
       (add-callback!
        service

--- a/rebel-readline/bb.edn
+++ b/rebel-readline/bb.edn
@@ -1,0 +1,6 @@
+{:deps {com.bhauman/rebel-readline {:local/root "."}}
+ :tasks {test:bb {:extra-paths ["test"]
+                  :extra-deps {io.github.cognitect-labs/test-runner
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                  :task (exec 'cognitect.test-runner.api/test)
+                  :exec-args {:dirs ["test"]}}}}

--- a/rebel-readline/deps.edn
+++ b/rebel-readline/deps.edn
@@ -4,7 +4,7 @@
         org.jline/jline-terminal-jni {:mvn/version "3.30.0"}
         org.jline/jline-terminal-ffm {:mvn/version "3.30.0"}
         dev.weavejester/cljfmt {:mvn/version "0.13.0"}
-        compliment/compliment {:mvn/version "0.7.1"}}
+        compliment/compliment {:mvn/version "0.8.0"}}
  :tools/usage {:ns-default rebel-readline.tool}
  :aliases {:repl-tool {:exec-fn rebel-readline.tool/repl}
            :rebel {:main-opts  ["-m" "rebel-readline.main"]}

--- a/rebel-readline/deps.edn
+++ b/rebel-readline/deps.edn
@@ -2,8 +2,9 @@
         org.jline/jline-reader {:mvn/version "3.30.0"}
         org.jline/jline-terminal {:mvn/version "3.30.0"}
         org.jline/jline-terminal-jni {:mvn/version "3.30.0"}
+        org.jline/jline-terminal-ffm {:mvn/version "3.30.0"}
         dev.weavejester/cljfmt {:mvn/version "0.13.0"}
-        compliment/compliment {:mvn/version "0.6.0"}}
+        compliment/compliment {:mvn/version "0.7.1"}}
  :tools/usage {:ns-default rebel-readline.tool}
  :aliases {:repl-tool {:exec-fn rebel-readline.tool/repl}
            :rebel {:main-opts  ["-m" "rebel-readline.main"]}

--- a/rebel-readline/src/rebel_readline/clojure/line_reader.clj
+++ b/rebel-readline/src/rebel_readline/clojure/line_reader.clj
@@ -28,7 +28,6 @@
     EndOfFileException
     EOFError
     Widget]
-   [org.jline.reader.impl LineReaderImpl]
    [org.jline.terminal TerminalBuilder]
    [org.jline.utils AttributedStringBuilder AttributedString AttributedStyle
     InfoCmp$Capability]))
@@ -885,7 +884,7 @@
      :cursor cursor}))
 
 (defn parsed-line [{:keys [word-index word word-cursor words tokens line cursor] :as parse-data}]
-  (proxy [ParsedLine clojure.lang.IMeta] []
+  (proxy [ParsedLine #_clojure.lang.IMeta] []
     (word [] word)
     (wordIndex [] word-index)
     (wordCursor [] word-cursor)

--- a/rebel-readline/src/rebel_readline/clojure/line_reader.clj
+++ b/rebel-readline/src/rebel_readline/clojure/line_reader.clj
@@ -28,9 +28,8 @@
     EndOfFileException
     EOFError
     Widget]
-   [org.jline.reader.impl LineReaderImpl DefaultParser BufferImpl]
+   [org.jline.reader.impl LineReaderImpl]
    [org.jline.terminal TerminalBuilder]
-   [org.jline.terminal.impl DumbTerminal]
    [org.jline.utils AttributedStringBuilder AttributedString AttributedStyle
     InfoCmp$Capability]))
 
@@ -903,23 +902,19 @@
 
 ;; a parser for jline that respects clojurisms
 (defn make-parser []
-  (doto
-      (proxy [DefaultParser] []
-        (isDelimiterChar [^CharSequence buffer pos]
-          (boolean (#{\space \tab \return \newline  \, \{ \} \( \) \[ \] }
-                    (.charAt buffer pos))))
-        (parse [^String line cursor ^Parser$ParseContext context]
-          (cond
-            (= context Parser$ParseContext/ACCEPT_LINE)
-            (when-not (or (and *accept-fn*
-                               (*accept-fn* line cursor))
-                          (accept-line line cursor))
-              (indent *line-reader* line cursor)
-              (throw (EOFError. -1 -1 "Unbalanced Expression" (str *ns*))))
-            (= context Parser$ParseContext/COMPLETE)
-            (parsed-line (parse-line line cursor))
-            :else (proxy-super parse line cursor context))))
-    (.setQuoteChars (char-array [\"]))))
+  (reify Parser
+    (parse [_ line cursor context]
+      (let [^String line line
+            ^Parser$ParseContext context context]
+        (cond
+          (= context Parser$ParseContext/ACCEPT_LINE)
+          (when-not (or (and *accept-fn*
+                             (*accept-fn* line cursor))
+                        (accept-line line cursor))
+            (indent *line-reader* line cursor)
+            (throw (EOFError. -1 -1 "Unbalanced Expression" (str *ns*))))
+          :else
+          (parsed-line (parse-line line cursor)))))))
 
 ;; ----------------------------------------
 ;; Jline completer for Clojure candidates

--- a/rebel-readline/src/rebel_readline/clojure/line_reader.clj
+++ b/rebel-readline/src/rebel_readline/clojure/line_reader.clj
@@ -840,7 +840,7 @@
               (apply [_]
                 (when-let [hooks (not-empty (:self-insert-hooks @*state*))]
                   (widget-exec #(doseq [hook hooks] (hook))))
-                (.apply orig)))))))
+                (.apply ^Widget orig)))))))
 
 ;; ----------------------------------------------------
 ;; ----------------------------------------------------

--- a/rebel-readline/src/rebel_readline/clojure/line_reader.clj
+++ b/rebel-readline/src/rebel_readline/clojure/line_reader.clj
@@ -76,7 +76,7 @@
 (defmethod -current-ns :default [_])
 
 (defn current-ns []
-  (-current-ns @*line-reader*))
+  (-current-ns @*state*))
 
 ;; Prompt
 ;; ----------------------------------------------
@@ -107,8 +107,8 @@
 
 (defn default-accept-line [line-str cursor]
   (or
-   (and *line-reader*
-        (= "vicmd" (.getKeyMap *line-reader*)))
+   (and *state*
+        (= "vicmd" (.getKeyMap (line-reader))))
    (let [cursor (min (count line-str) cursor)
          x (subs line-str 0 cursor)
          tokens (tokenize/tag-sexp-traversal x)]
@@ -118,7 +118,7 @@
   (default-accept-line line-str cursor))
 
 (defn accept-line [line-str cursor]
-  (-accept-line @*line-reader* line-str cursor))
+  (-accept-line @*state* line-str cursor))
 
 ;; Completion
 ;; ----------------------------------------------
@@ -145,7 +145,7 @@
   ([word]
    (completions word nil))
   ([word options]
-   (-complete @*line-reader* word options)))
+   (-complete @*state* word options)))
 
 ;; ResolveMeta
 ;; ----------------------------------------------
@@ -168,7 +168,7 @@
 (defmethod -resolve-meta :default [service _])
 
 (defn resolve-meta [wrd]
-  (-resolve-meta @*line-reader* wrd))
+  (-resolve-meta @*state* wrd))
 
 ;; ----------------------------------------------
 ;; multi-methods that have to be defined or they
@@ -200,7 +200,7 @@
 (defmethod -source :default [service _])
 
 (defn source [wrd]
-  (-source @*line-reader* wrd))
+  (-source @*state* wrd))
 
 ;; Apropos
 ;; ----------------------------------------------
@@ -214,7 +214,7 @@
 (defmethod -apropos :default [service _])
 
 (defn apropos [wrd]
-  (-apropos @*line-reader* wrd))
+  (-apropos @*state* wrd))
 
 ;; Doc
 ;; ----------------------------------------------
@@ -234,7 +234,7 @@
 (defmethod -doc :default [service _])
 
 (defn doc [wrd]
-  (-doc @*line-reader* wrd))
+  (-doc @*state* wrd))
 
 ;; ReadString
 ;; ----------------------------------------------
@@ -245,20 +245,20 @@
   key `:form`
 
   Example:
-  (-read-string @api/*line-reader* \"1\") => {:form 1}
+  (-read-string @api/*state* \"1\") => {:form 1}
 
   If an exception is thrown this will return a throwable map under
   the key `:exception`
 
   Example:
-  (-read-string @api/*line-reader* \"#asdfasdfas\") => {:exception {:cause ...}}"
+  (-read-string @api/*state* \"#asdfasdfas\") => {:exception {:cause ...}}"
   service-dispatch)
 
 (defmethod -read-string :default [service _]
   (tools/not-implemented! service "-read-string"))
 
 (defn read-form [form-str]
-  (-read-string @*line-reader* form-str))
+  (-read-string @*state* form-str))
 
 ;; Eval
 ;; ----------------------------------------------
@@ -276,13 +276,13 @@
   of the form.
 
   Example:
-  (-eval @api/*line-reader* 1) => {:result 1 :out \"\" :err \"\"}
+  (-eval @api/*state* 1) => {:result 1 :out \"\" :err \"\"}
 
   If an exception is thrown this will return a throwable map under
   the key `:exception`
 
   Example:
-  (-eval @api/*line-reader* '(defn)) => {:exception {:cause ...}}
+  (-eval @api/*state* '(defn)) => {:exception {:cause ...}}
 
   An important thing to remember abou this eval is that it is used
   internally by the line-reader to implement various
@@ -293,7 +293,7 @@
   (tools/not-implemented! service "-eval"))
 
 (defn evaluate [form]
-  (-eval @*line-reader* form))
+  (-eval @*state* form))
 
 ;; EvalString
 ;; ----------------------------------------------
@@ -316,7 +316,7 @@
       {:exception (Throwable->map e)})))
 
 (defn evaluate-str [form-str]
-  (-eval-str @*line-reader* form-str))
+  (-eval-str @*state* form-str))
 
 ;; ----------------------------------------------------
 ;; ----------------------------------------------------
@@ -354,7 +354,7 @@
          columns     (:cols (terminal-size))
          at-str-lines (split-into-wrapped-lines at-str columns)
          rows-needed (count at-str-lines)
-         menu-keys   (get (.getKeyMaps *line-reader*)
+         menu-keys   (get (.getKeyMaps (line-reader))
                           LineReader/MENU)]
      (if (< (+ rows-needed
                (lines-needed (:header options) columns)
@@ -386,7 +386,8 @@
                                    (window-lines at-str-lines pos window-rows)
                                    footer])))
                (redisplay)
-               (let [o (.readBinding *line-reader* (.getKeys ^LineReader *line-reader*) menu-keys)
+               (let [lr (line-reader)
+                     o (.readBinding lr (.getKeys ^LineReader lr) menu-keys)
                      binding-name (.name ^org.jline.reader.Reference o)]
                  (condp contains? binding-name
                    #{LineReader/UP_LINE_OR_HISTORY
@@ -404,9 +405,9 @@
                      ;; clear the post display
                      (display-message "  ")
                      ;; pushback binding
-                     (when-let [s (.getLastBinding *line-reader*)]
+                     (when-let [s (.getLastBinding lr)]
                        (when (not= "q" s)
-                         (.runMacro *line-reader* s)))))))
+                         (.runMacro lr s)))))))
              ;; window is too small do nothing
              nil)))))))
 
@@ -455,7 +456,7 @@
 
 (def indent-line-widget
   (create-widget
-   (when (:indent @*line-reader*)
+   (when (:indent @*state*)
        (let [curs (cursor)
              s (buffer-as-string) ;; up-to-cursor better here?
              begin-of-line-pos   (sexp/search-for-line-start s (dec curs))
@@ -537,7 +538,7 @@
     ;; hook here
     ;; if prev-char is a space and the char before that is part
     ;; of a word, and that word is a fn call
-    (when (:eldoc @*line-reader*)
+    (when (:eldoc @*state*)
       (when-let [message (display-argument-help-message)]
         (reset! ttd-atom 1)
         (display-message message)))))
@@ -765,20 +766,19 @@
 ;; Base Widget registration and binding helpers
 ;; --------------------------------------------
 
-(defn add-all-widgets [line-reader]
-  (binding [*line-reader* line-reader]
-    (register-widget "clojure-indent-line"        indent-line-widget)
-    (register-widget "clojure-indent-or-complete" indent-or-complete-widget)
+(defn add-all-widgets []
+  (register-widget "clojure-indent-line"        indent-line-widget)
+  (register-widget "clojure-indent-or-complete" indent-or-complete-widget)
 
-    (register-widget "clojure-doc-at-point"       document-at-point-widget)
-    (register-widget "clojure-source-at-point"    source-at-point-widget)
-    (register-widget "clojure-apropos-at-point"   apropos-at-point-widget)
-    (register-widget "clojure-eval-at-point"      eval-at-point-widget)
+  (register-widget "clojure-doc-at-point"       document-at-point-widget)
+  (register-widget "clojure-source-at-point"    source-at-point-widget)
+  (register-widget "clojure-apropos-at-point"   apropos-at-point-widget)
+  (register-widget "clojure-eval-at-point"      eval-at-point-widget)
 
-    (register-widget "clojure-force-accept-line"  always-accept-line)
+  (register-widget "clojure-force-accept-line"  always-accept-line)
 
-    (register-widget "end-of-buffer"              end-of-buffer)
-    (register-widget "beginning-of-buffer"        beginning-of-buffer)))
+  (register-widget "end-of-buffer"              end-of-buffer)
+  (register-widget "beginning-of-buffer"        beginning-of-buffer))
 
 (defn bind-indents [km-name]
   (doto km-name
@@ -802,19 +802,16 @@
     (key-binding (str \\ \e) "clojure-eval-at-point")))
 
 (defn clojure-emacs-mode [km-name]
-  (doto km-name
-    bind-indents
-    bind-clojure-widgets
-    (key-binding
-     (KeyMap/key
-      (.getTerminal *line-reader*)
-      InfoCmp$Capability/key_end)
-     "end-of-buffer")
-    (key-binding
-     (KeyMap/key
-      (.getTerminal *line-reader*)
-      InfoCmp$Capability/key_home)
-     "beginning-of-buffer")))
+  (let [terminal (.getTerminal (line-reader))]
+    (doto km-name
+      bind-indents
+      bind-clojure-widgets
+      (key-binding
+       (KeyMap/key terminal InfoCmp$Capability/key_end)
+       "end-of-buffer")
+      (key-binding
+       (KeyMap/key terminal InfoCmp$Capability/key_home)
+       "beginning-of-buffer"))))
 
 (defn clojure-vi-insert-mode [km-name]
   (doto km-name
@@ -827,15 +824,23 @@
     bind-clojure-widgets
     bind-clojure-widgets-vi-cmd))
 
-(defn add-widgets-and-bindings [line-reader]
-  (binding [*line-reader* line-reader]
+(defn add-widgets-and-bindings []
+  (let [lr (line-reader)]
     (clojure-emacs-mode :emacs)
     (clojure-vi-insert-mode :viins)
     (clojure-vi-cmd-mode :vicmd)
-    (swap! line-reader #(update % :self-insert-hooks (fnil conj #{}) eldoc-self-insert-hook))
-    (doto line-reader
-      (.setVariable LineReader/WORDCHARS "")
-      add-all-widgets)))
+    (swap! *state* update :self-insert-hooks (fnil conj #{}) eldoc-self-insert-hook)
+    (.setVariable lr LineReader/WORDCHARS "")
+    (add-all-widgets)
+    ;; wrap self-insert widget to run hooks before each keystroke
+    (let [widgets (.getWidgets lr)
+          orig (.get widgets LineReader/SELF_INSERT)]
+      (.put widgets "self-insert"
+            (reify Widget
+              (apply [_]
+                (when-let [hooks (not-empty (:self-insert-hooks @*state*))]
+                  (widget-exec #(doseq [hook hooks] (hook))))
+                (.apply orig)))))))
 
 ;; ----------------------------------------------------
 ;; ----------------------------------------------------
@@ -911,7 +916,7 @@
           (when-not (or (and *accept-fn*
                              (*accept-fn* line cursor))
                         (accept-line line cursor))
-            (indent *line-reader* line cursor)
+            (indent (line-reader) line cursor)
             (throw (EOFError. -1 -1 "Unbalanced Expression" (str *ns*))))
           :else
           (parsed-line (parse-line line cursor)))))))
@@ -993,7 +998,7 @@
     (complete [^LineReader reader ^ParsedLine line ^java.util.List candidates]
       (let [word (.word line)]
         (when (and
-               (:completion @*line-reader*)
+               (:completion @*state*)
                (not (string/blank? word))
                (pos? (count word)))
           (let [options (let [ns' (current-ns)
@@ -1014,14 +1019,14 @@
 ;; Jline highlighter for Clojure code
 ;; ----------------------------------------
 
-(defn clojure-highlighter []
+(defn clojure-highlighter [state]
   (proxy [Highlighter] []
     (highlight [^LineReader reader ^String buffer]
       ;; this gets called on a different thread
       ;; by the window resize interrupt handler
-      ;; so add this binding here
-      (binding [*line-reader* reader]
-        (if (:highlight @reader)
+      ;; so bind *state* here from the captured atom
+      (binding [*state* state]
+        (if (:highlight @state)
           (.toAttributedString (highlight-clj-str buffer))
           (AttributedString. buffer))))))
 
@@ -1032,24 +1037,24 @@
 (defn create* [terminal service & [{:keys [completer highlighter parser]}]]
   {:pre [(instance? org.jline.terminal.Terminal terminal)
          (map? service)]}
-  (doto (create-line-reader terminal "Clojure Readline" service)
-    (.setCompleter (or completer (clojure-completer)))
-    (.setHighlighter (or highlighter (clojure-highlighter )))
-    (.setParser (or parser (make-parser)))
-    ;; make sure that we don't have to double escape things
-    (.setOpt LineReader$Option/DISABLE_EVENT_EXPANSION)
-        ;; never insert tabs
-    (.unsetOpt LineReader$Option/INSERT_TAB)
-    (.setVariable LineReader/SECONDARY_PROMPT_PATTERN "%P #_=> ")
-    ;; history
-    (.setVariable LineReader/HISTORY_FILE (str (io/file ".rebel_readline_history")))
-    (.setOpt LineReader$Option/HISTORY_REDUCE_BLANKS)
-    (.setOpt LineReader$Option/HISTORY_IGNORE_DUPS)
-    (.setOpt LineReader$Option/HISTORY_INCREMENTAL)
-    add-widgets-and-bindings
-    (#(binding [*line-reader* %]
-        (apply-key-bindings!)
-        (set-main-key-map! (get service :key-map :emacs))))))
+  (let [reader (create-line-reader terminal "Clojure Readline")
+        state (atom (assoc service :line-reader reader))]
+    (doto reader
+      (.setCompleter (or completer (clojure-completer)))
+      (.setHighlighter (or highlighter (clojure-highlighter state)))
+      (.setParser (or parser (make-parser)))
+      (.setOpt LineReader$Option/DISABLE_EVENT_EXPANSION)
+      (.unsetOpt LineReader$Option/INSERT_TAB)
+      (.setVariable LineReader/SECONDARY_PROMPT_PATTERN "%P #_=> ")
+      (.setVariable LineReader/HISTORY_FILE (str (io/file ".rebel_readline_history")))
+      (.setOpt LineReader$Option/HISTORY_REDUCE_BLANKS)
+      (.setOpt LineReader$Option/HISTORY_IGNORE_DUPS)
+      (.setOpt LineReader$Option/HISTORY_INCREMENTAL))
+    (binding [*state* state]
+      (add-widgets-and-bindings)
+      (apply-key-bindings!)
+      (set-main-key-map! (get service :key-map :emacs)))
+    state))
 
 (defn create
   "Creates a line reader takes a service as an argument.

--- a/rebel-readline/src/rebel_readline/clojure/main.clj
+++ b/rebel-readline/src/rebel_readline/clojure/main.clj
@@ -26,13 +26,13 @@
   This printer respects the current color settings set in the
   service.
 
-  The `rebel-readline.jline-api/*line-reader*` and
+  The `rebel-readline.jline-api/*state*` and
   `rebel-readline.jline-api/*service*` dynamic vars have to be set for
   this to work.
 
   See `rebel-readline.main` for an example of how this function is normally used"
   [x]
-  (binding [*out* (.. api/*line-reader* getTerminal writer)]
+  (binding [*out* (.. (api/line-reader) getTerminal writer)]
     (syntax-highlight-prn-unwrapped x)))
 
 (defn syntax-highlight-prn
@@ -41,7 +41,7 @@
   This printer respects the current color settings set in the
   service.
 
-  The `rebel-readline.jline-api/*line-reader*` and
+  The `rebel-readline.jline-api/*state*` and
   `rebel-readline.jline-api/*service*` dynamic vars have to be set for
   this to work.
 
@@ -91,7 +91,7 @@
           ;; would prefer not to have this here
           final-config (merge clj-line-reader/default-config
                               (tools/user-config ::tools/arg-map config)
-                              (when api/*line-reader* @api/*line-reader*)
+                              (when api/*state* @api/*state*)
                               config)]
       (core/with-line-reader
           (clj-line-reader/create
@@ -104,9 +104,9 @@
         ;; the prompt from corruption by ensuring a newline on flush and
         ;; forcing a prompt to redisplay if the output is printed while
         ;; the readline editor is enguaged
-          (binding [*out* (api/safe-terminal-writer api/*line-reader*)]
+          (binding [*out* (api/safe-terminal-writer (api/line-reader))]
             (when-let [prompt-fn (:prompt opts)]
-              (swap! api/*line-reader* assoc :prompt prompt-fn))
+              (swap! api/*state* assoc :prompt prompt-fn))
             (println (core/help-message))
             (apply
              clj-repl

--- a/rebel-readline/src/rebel_readline/commands.clj
+++ b/rebel-readline/src/rebel_readline/commands.clj
@@ -20,8 +20,8 @@
   "Toggle the automatic indenting of Clojure code on and off.")
 
 (defmethod command :repl/toggle-indent [_]
-  (swap! api/*line-reader* update :indent #(not %))
-  (if (:indent @api/*line-reader*)
+  (swap! api/*state* update :indent #(not %))
+  (if (:indent @api/*state*)
     (println "Indenting on!")
     (println "Indenting off!")))
 
@@ -30,8 +30,8 @@
 `:repl/toggle-color` if you want to turn color off completely.")
 
 (defmethod command :repl/toggle-highlight [_]
-  (swap! api/*line-reader* update :highlight #(not %))
-  (if (:highlight @api/*line-reader*)
+  (swap! api/*state* update :highlight #(not %))
+  (if (:highlight @api/*state*)
     (println "Highlighting on!")
     (println "Highlighting off!")))
 
@@ -39,8 +39,8 @@
   "Toggle the auto display of function signatures on and off.")
 
 (defmethod command :repl/toggle-eldoc [_]
-  (swap! api/*line-reader* update :eldoc #(not %))
-  (if (:eldoc @api/*line-reader*)
+  (swap! api/*state* update :eldoc #(not %))
+  (if (:eldoc @api/*state*)
     (println "Eldoc on!")
     (println "Eldoc off!")))
 
@@ -48,8 +48,8 @@
   "Toggle the completion functionality on and off.")
 
 (defmethod command :repl/toggle-completion [_]
-  (swap! api/*line-reader* update :completion #(not %))
-  (if (:completion @api/*line-reader*)
+  (swap! api/*state* update :completion #(not %))
+  (if (:completion @api/*state*)
     (println "Completion on!")
     (println "Completion off!")))
 
@@ -57,21 +57,21 @@
   "Toggle ANSI text coloration on and off.")
 
 (defmethod command :repl/toggle-color [_]
-  (let [{:keys [color-theme backup-color-theme]} @api/*line-reader*]
+  (let [{:keys [color-theme backup-color-theme]} @api/*state*]
     (cond
       (and (nil? color-theme)
            (some? backup-color-theme)
            (tools/color-themes backup-color-theme))
       (do (println "Activating color, using theme: " backup-color-theme)
-          (swap! api/*line-reader* assoc :color-theme backup-color-theme))
+          (swap! api/*state* assoc :color-theme backup-color-theme))
       (nil? color-theme)
       (do
-        (swap! api/*line-reader* assoc :color-theme :dark-screen-theme)
+        (swap! api/*state* assoc :color-theme :dark-screen-theme)
         (println "Activating color, theme not found, defaulting to " :dark-screen-theme))
       (some? color-theme)
       (do
-        (swap! api/*line-reader* assoc :backup-color-theme color-theme)
-        (swap! api/*line-reader* dissoc :color-theme)
+        (swap! api/*state* assoc :backup-color-theme color-theme)
+        (swap! api/*state* dissoc :color-theme)
         (println "Color deactivated!")))))
 
 (defmethod command-doc :repl/set-color-theme [_]
@@ -88,7 +88,7 @@
             "\n"
             (with-out-str
               (pprint (keys tools/color-themes)))))
-      (swap! api/*line-reader* assoc :color-theme new-theme))))
+      (swap! api/*state* assoc :color-theme new-theme))))
 
 (defmethod command-doc :repl/key-bindings [_]
   "With an argument displays a search of the current key bindings
@@ -111,7 +111,7 @@ Without any arguments displays all the current key bindings")
         (dissoc true false))))
 
 (defn display-key-bindings [search & groups]
-  (let [km (get (.getKeyMaps api/*line-reader*) "main")
+  (let [km (get (.getKeyMaps (api/line-reader)) "main")
         key-data (filter
                   (if search
                     (fn [[k v]]
@@ -165,7 +165,7 @@ Without any arguments displays all the current key bindings")
      ;; its dicey to have parallel state like this so
      ;; we are just going to have the service config
      ;; state reflect the jline reader state
-     (swap! api/*line-reader*
+     (swap! api/*state*
             assoc :key-map (keyword (api/main-key-map-name))))))
 
 (defmethod command :repl/set-key-map [[_ key-map-name]]
@@ -229,7 +229,7 @@ by evaluated code you should use *e* to inspect those.  This is mainly
 to diagnose problems in the toolchain. ")
 
 (defmethod command :repl/*e [n]
-  (some-> api/*line-reader*
+  (some-> api/*state*
           deref
           :repl/error
           deref

--- a/rebel-readline/src/rebel_readline/core.clj
+++ b/rebel-readline/src/rebel_readline/core.clj
@@ -51,10 +51,8 @@
      ~@body))
 
 (defmacro with-line-reader
-  "This macro take a line-reader and binds it.  It is one of the
-  primary ways to utilize this library. You can think of the
-  rebel-readline.jline-api/*line-reader* binding as an alternative in
-  source that the rebel-readline.core/read-line function reads from.
+  "This macro takes a state atom and binds it. It is one of the
+  primary ways to utilize this library.
 
   Example:
   (require '[rebel-readline.core :as rebel])
@@ -62,17 +60,14 @@
   (rebel/with-line-reader
     (rebel-readline.clojure.line-reader/create
       (rebel-readline.clojure.service.local/create))
-    ;; optionally bind the output directly to the jline terminal
-    ;; in such a way so that output won't corrupt the terminal
-    ;; this is optional
-    (binding [*out* (rebel-readline.jline-api/safe-terminal-writer)]
+    (binding [*out* (rebel-readline.jline-api/safe-terminal-writer
+                      (rebel-readline.jline-api/line-reader))]
       (clojure.main/repl
-        ;; this will create a fn that reads from the *line-reader*
         :read (rebel-readline.clojure.main/create-repl-read)
        :prompt (fn []))))"
-  [line-reader & body]
+  [state & body]
   `(ensure-terminal
-    (binding [rebel-readline.jline-api/*line-reader* ~line-reader]
+    (binding [rebel-readline.jline-api/*state* ~state]
       ~@body)))
 
 (defn help-message
@@ -103,9 +98,10 @@
        command-executed :command-executed
        :or {prompt nil buffer nil mask nil command-executed ""}}]
   
-  (let [redirect-output? (:redirect-output @api/*line-reader*)
+  (let [lr (api/line-reader)
+        redirect-output? (:redirect-output @api/*state*)
         save-out (volatile! *out*)
-        redirect-print-writer (api/safe-terminal-writer api/*line-reader*)]
+        redirect-print-writer (api/safe-terminal-writer lr)]
     (when redirect-output?
       (alter-var-root
        #'*out*
@@ -118,7 +114,7 @@
         ;; but we are blocking concurrent redisplays while the
         ;; readline prompt is initially drawn
         (api/block-redisplay-millis 100)
-        (let [res' (.readLine api/*line-reader* (or prompt (tools/prompt)) mask buffer)]
+        (let [res' (.readLine lr (or prompt (tools/prompt)) mask buffer)]
           (if-not (commands/handle-command res')
             res'
             command-executed)))
@@ -129,7 +125,7 @@
 
 (defn read-line
   "Reads a line from the currently bound
-  rebel-readline.jline-api/*line-reader*. If you supply the optional
+  rebel-readline.jline-api/*state*. If you supply the optional
   `command-executed` sentinal value, it will be returned when a repl
   command is executed, otherwise a blank string will be returned when
   a repl command is executed.
@@ -258,4 +254,6 @@
        ~@body)))
 
 (defn basic-line-reader [& opts]
-  (api/create-line-reader api/*terminal* nil (apply hash-map opts)))
+  (let [service (apply hash-map opts)
+        reader (api/create-line-reader api/*terminal* nil)]
+    (atom (assoc service :line-reader reader))))

--- a/rebel-readline/src/rebel_readline/jline_api.clj
+++ b/rebel-readline/src/rebel_readline/jline_api.clj
@@ -18,9 +18,8 @@
     EndOfFileException
     EOFError
     Widget]
-   [org.jline.reader.impl LineReaderImpl DefaultParser BufferImpl]
+   [org.jline.reader.impl LineReaderImpl]
    [org.jline.terminal Terminal TerminalBuilder Attributes Attributes$LocalFlag Attributes$InputFlag]
-   [org.jline.terminal.impl DumbTerminal]
    [java.io Writer]
    [org.jline.utils AttributedStringBuilder AttributedString AttributedStyle]))
 
@@ -28,27 +27,12 @@
 (def ^:dynamic *line-reader* nil)
 (def ^:dynamic *buffer* nil)
 
-;; helper for development
-(defn buffer*
-  ([s] (buffer* s nil))
-  ([s c]
-   (doto (BufferImpl.)
-     (.write s)
-     (.cursor (or c (count s))))))
-
-;; helper for development
-#_(defmacro with-buffer [b & body]
-  `(binding [rebel-readline.jline-api/*buffer* ~b
-             rebel-readline.service/*service*
-             (rebel-readline.service.local-clojure/create)]
-     ~@body))
-
 ;; ----------------------------------------
 ;; Create a terminal
 ;; ----------------------------------------
 
 (defn assert-system-terminal [terminal]
-  (when (instance? DumbTerminal terminal)
+  (when (= "dumb" (.getType ^Terminal terminal))
     (throw (ex-info
 "Unable to detect a system Terminal, you must not launch the Rebel readline
 from an intermediate process.

--- a/rebel-readline/src/rebel_readline/jline_api.clj
+++ b/rebel-readline/src/rebel_readline/jline_api.clj
@@ -19,7 +19,6 @@
     EndOfFileException
     EOFError
     Widget]
-   [org.jline.reader.impl LineReaderImpl]
    [org.jline.terminal Terminal TerminalBuilder Attributes Attributes$LocalFlag Attributes$InputFlag]
    [java.io Writer]
    [org.jline.utils AttributedStringBuilder AttributedString AttributedStyle]))
@@ -278,7 +277,10 @@ If you are using `lein` you may need to use `lein trampoline`."
   (.callWidget (line-reader) widget-name))
 
 (defn create-line-reader [terminal app-name]
-  (LineReaderImpl. terminal (or app-name "Rebel Readline") nil))
+  (-> (LineReaderBuilder/builder)
+      (.terminal terminal)
+      (.appName (or app-name "Rebel Readline"))
+      (.build)))
 
 ;; taken from Clojure 1.10 core.print
 (defn- ^java.io.PrintWriter PrintWriter-on*

--- a/rebel-readline/src/rebel_readline/jline_api.clj
+++ b/rebel-readline/src/rebel_readline/jline_api.clj
@@ -5,6 +5,7 @@
   (:import
    [org.jline.keymap KeyMap]
    [org.jline.reader
+    Buffer
     Highlighter
     Completer
     Candidate
@@ -92,8 +93,8 @@ If you are using `lein` you may need to use `lein trampoline`."
                    (recur (.getSuperclass clazz))))))))
 
 (defn supplier [f]
-  (proxy [java.util.function.Supplier] []
-    (get [] (f))))
+  (reify java.util.function.Supplier
+    (get [_] (f))))
 
 ;; --------------------------------------
 ;; Key maps

--- a/rebel-readline/src/rebel_readline/jline_api.clj
+++ b/rebel-readline/src/rebel_readline/jline_api.clj
@@ -24,8 +24,10 @@
    [org.jline.utils AttributedStringBuilder AttributedString AttributedStyle]))
 
 (def ^:dynamic *terminal* nil)
-(def ^:dynamic *line-reader* nil)
+(def ^:dynamic *state* nil)
 (def ^:dynamic *buffer* nil)
+
+(defn line-reader [] (:line-reader @*state*))
 
 ;; ----------------------------------------
 ;; Create a terminal
@@ -59,15 +61,14 @@ If you are using `lein` you may need to use `lein trampoline`."
 
 (declare display-message)
 
-(defn widget-exec [line-reader thunk]
-  (binding [*line-reader* line-reader
-            *buffer* (.getBuffer line-reader)]
+(defn widget-exec [thunk]
+  (binding [*buffer* (.getBuffer (line-reader))]
     (try
       (thunk)
       (catch clojure.lang.ExceptionInfo e
         (if-let [message (.getMessage e)]
           (do
-            (some-> @line-reader :repl/error (reset! e))
+            (some-> @*state* :repl/error (reset! e))
             (display-message
              (AttributedString.
               (str "Internal REPL Error: this shouldn't happen. :repl/*e for stacktrace\n"
@@ -77,20 +78,18 @@ If you are using `lein` you may need to use `lein trampoline`."
           (throw e))))))
 
 (defmacro create-widget [& body]
-  `(fn [line-reader#]
-     (reify Widget
-       (apply [_#]
-         (widget-exec line-reader# (fn [] ~@body))))))
+  `(reify Widget
+     (apply [_#]
+       (widget-exec (fn [] ~@body)))))
 
-;; very naive
 (def get-accessible-field
   (memoize (fn [obj field-name]
-             (or (when-let [field (-> obj
-                                      .getClass
-                                      .getSuperclass
-                                      (.getDeclaredField field-name))]
-                   (doto field
-                     (.setAccessible true)))))))
+             (loop [clazz (.getClass obj)]
+               (when clazz
+                 (if-let [field (try (.getDeclaredField clazz field-name)
+                                     (catch Exception _ nil))]
+                   (doto field (.setAccessible true))
+                   (recur (.getSuperclass clazz))))))))
 
 (defn supplier [f]
   (proxy [java.util.function.Supplier] []
@@ -124,7 +123,7 @@ If you are using `lein` you may need to use `lein trampoline`."
               "do-lowercase-version"} v))))))
 
 (defn key-maps []
-  (-> *line-reader* (.getKeyMaps)))
+  (-> (line-reader) (.getKeyMaps)))
 
 (defn key-map [key-map-name]
   (get (key-maps) (name key-map-name)))
@@ -148,14 +147,14 @@ If you are using `lein` you may need to use `lein trampoline`."
   (key-map-name (key-map "main")))
 
 (defn orig-key-map-clone [key-map-name]
-  (get (.defaultKeyMaps *line-reader*) key-map-name))
+  (get (.defaultKeyMaps (line-reader)) key-map-name))
 
 (defn bind-key [key-map widget-id key-str]
   (when key-str
     (.bind key-map (org.jline.reader.Reference. widget-id) key-str)))
 
 (defn key-binding [key-map-name key-str widget-name]
-  (swap! *line-reader* update-in
+  (swap! *state* update-in
          [::key-bindings (keyword key-map-name)]
          #((fnil conj []) % [key-str widget-name])))
 
@@ -169,19 +168,18 @@ If you are using `lein` you may need to use `lein trampoline`."
        (set-key-map! (name key-map-name) km)))))
 
 (defn apply-key-bindings! []
-  (when-let [kbs (not-empty (::key-bindings @*line-reader*))]
+  (when-let [kbs (not-empty (::key-bindings @*state*))]
     (apply-key-bindings kbs))
   ;; user level key bindings applied after
-  (when-let [kbs (not-empty (:key-bindings @*line-reader*))]
-    (apply-key-bindings kbs :look-up-keymap-fn key-map))
-  *line-reader*)
+  (when-let [kbs (not-empty (:key-bindings @*state*))]
+    (apply-key-bindings kbs :look-up-keymap-fn key-map)))
 
 ;; --------------------------------------
 ;; contextual ANSI
 ;; --------------------------------------
 
 (defn ->ansi [at-str]
-  (if-let [t (and *line-reader* (.getTerminal *line-reader*))]
+  (if-let [t (and *state* (.getTerminal (line-reader)))]
     (astring/->ansi at-str t)
     (astring/->ansi at-str nil)))
 
@@ -238,22 +236,22 @@ If you are using `lein` you may need to use `lein trampoline`."
 ;; --------------------------------------
 
 (defn register-widget [widget-id widget]
-  (doto *line-reader*
-    (-> (.getWidgets)
-        (.put widget-id (if (fn? widget) (widget *line-reader*) widget)))))
+  (-> (line-reader) (.getWidgets) (.put widget-id widget)))
 
 (defn terminal-size []
-  (let [size-field (get-accessible-field *line-reader* "size")]
-    (when-let [sz (.get size-field *line-reader*)]
+  (let [lr (line-reader)
+        size-field (get-accessible-field lr "size")]
+    (when-let [sz (.get size-field lr)]
       {:rows (.getRows sz)
        :cols (.getColumns sz)})))
 
 (defn redisplay []
-  (locking (.writer (.getTerminal *line-reader*))
-    (.redisplay *line-reader*)))
+  (let [lr (line-reader)]
+    (locking (.writer (.getTerminal lr))
+      (.redisplay lr))))
 
 (defn block-redisplay-millis [time-ms]
-  (let [writer (.writer (.getTerminal *line-reader*))]
+  (let [writer (.writer (.getTerminal (line-reader)))]
     (.start
      (Thread.
       (fn []
@@ -262,10 +260,10 @@ If you are using `lein` you may need to use `lein trampoline`."
 
 (defn display-message
   ([message]
-   (display-message *line-reader* message))
-  ([line-reader message]
-   (let [post-field (get-accessible-field line-reader "post")]
-     (.set post-field line-reader (supplier (fn [] (AttributedString. message)))))))
+   (display-message (line-reader) message))
+  ([lr message]
+   (let [post-field (get-accessible-field lr "post")]
+     (.set post-field lr (supplier (fn [] (AttributedString. message)))))))
 
 (defn rows-available-for-post-display []
   (let [rows (:rows (terminal-size))
@@ -276,24 +274,10 @@ If you are using `lein` you may need to use `lein trampoline`."
   (.isReading line-reader))
 
 (defn call-widget [widget-name]
-  (.callWidget *line-reader* widget-name))
+  (.callWidget (line-reader) widget-name))
 
-(defn create-line-reader [terminal app-name service]
-  (let [service-variable-name (str ::service)]
-    (proxy [LineReaderImpl clojure.lang.IDeref clojure.lang.IAtom]
-        [terminal
-         (or app-name "Rebel Readline")
-         (java.util.HashMap. {service-variable-name (atom (or service {}))})]
-      (selfInsert []
-        (when-let [hooks (not-empty (:self-insert-hooks @this))]
-          (widget-exec this #(doseq [hook hooks] (hook))))
-        (proxy-super selfInsert))
-      (deref []
-        (deref (.getVariable this service-variable-name)))
-      (swap  [f & args]
-        (apply swap! (.getVariable this service-variable-name) f args))
-      (reset [a]
-        (reset! (.getVariable this service-variable-name) a)))))
+(defn create-line-reader [terminal app-name]
+  (LineReaderImpl. terminal (or app-name "Rebel Readline") nil))
 
 ;; taken from Clojure 1.10 core.print
 (defn- ^java.io.PrintWriter PrintWriter-on*
@@ -335,4 +319,3 @@ If you are using `lein` you may need to use `lein trampoline`."
              (.flush))
            (.setLength buffer 0)))))
    nil))
-

--- a/rebel-readline/src/rebel_readline/tools.clj
+++ b/rebel-readline/src/rebel_readline/tools.clj
@@ -28,7 +28,7 @@
 
 (defn color [sk]
   (->
-   (get @api/*line-reader* :color-theme)
+   (get @api/*state* :color-theme)
    color-themes
    (get sk AttributedStyle/DEFAULT)))
 
@@ -198,10 +198,10 @@
 (defmethod -prompt :default [_] "")
 
 (defn prompt []
-  (if-let [f (resolve-fn? (:prompt @api/*line-reader*))]
+  (if-let [f (resolve-fn? (:prompt @api/*state*))]
     ;; follow the prompt function convention here
     (with-out-str (f))
-    (-prompt @api/*line-reader*)))
+    (-prompt @api/*state*)))
 
 ;; Initial Themes
 


### PR DESCRIPTION
- Refactors using public JLine only (which is the only exposed API in bb). That's the reason we now use a `*state*` dynvar instead of a proxy on `DefaultReader`.
- Adds Github CI config for testing.
- Bumps compliment to 0.8.0 which is now bb compatible.
- Switch CLJS example to node instead of nashorn (deprecated)